### PR TITLE
Enable stress tester application server to run in windows

### DIFF
--- a/bin/build_browser_app.bat
+++ b/bin/build_browser_app.bat
@@ -1,0 +1,23 @@
+ECHO OFF
+
+rem delete contents of old browser build
+IF EXIST browser_build (
+rmdir /s /q browser_build
+) ELSE (
+mkdir browser_build
+)
+
+rem build browser tests
+call npm run build_browser_app_windows
+
+rem copy dependencies to browser build
+copy node_modules\monero-javascript\dist\monero_core.js browser_build\monero_core.js
+copy node_modules\monero-javascript\dist\monero_core.wasm browser_build\monero_core.wasm
+copy node_modules\monero-javascript\dist\monero_core_keys.js browser_build\monero_core_keys.js
+copy node_modules\monero-javascript\dist\monero_core_keys.wasm browser_build\monero_core_keys.wasm
+copy node_modules\monero-javascript\dist\MoneroWebWorker.dist.js browser_build\MoneroWebWorker.dist.js
+copy node_modules\monero-javascript\dist\MoneroWebWorker.dist.js.map browser_build\MoneroWebWorker.dist.js.map
+xcopy src\main browser_build
+
+rem start server
+bin\start_dev_server.bat

--- a/bin/build_browser_app.sh
+++ b/bin/build_browser_app.sh
@@ -5,7 +5,7 @@ mkdir -p ./browser_build/ || exit 1
 rm -r ./browser_build/ || exit 1
 
 # build browser tests
-npm run build_browser_app || exit 1
+npm run build_browser_app_unix || exit 1
 
 # copy dependencies to browser build
 cp node_modules/monero-javascript/dist/monero_core.js browser_build/monero_core.js

--- a/bin/start_dev_server.bat
+++ b/bin/start_dev_server.bat
@@ -1,0 +1,3 @@
+cd browser_build
+..\bin\run_server.py
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Web app to stress test the Monero network by generating transactions",
   "main": "src/index.js",
   "scripts": {
-    "build_browser_app": "webpack --config ./webpack.config.js",
+    "build_browser_app_unix": "webpack --config ./webpack.config.js",
+    "build_browser_app_windows": "webpack --config .\webpack.config.js",
     "test": "node --experimental-wasm-threads --experimental-wasm-bulk-memory node_modules/mocha/bin/_mocha 'src/test/TestAll' --timeout 3000000 --exit"
   },
   "repository": {


### PR DESCRIPTION
* Convert build_browser_app.sh to batch file
* Convert start_dev_server.sh to batch file
* Modify package.json to split build_browser app into separate linux and windows versions
  - build_browser_app_linux
  - build_browser_app_windows
* Modify build_browser_app.sh to point to the build_browser_app_linux script in package.json
--------
Fix unintended modification to build_browser_app script

* change "cp -R src/* browser_build/" back to "cp -R src/main/* browser_build/"
* Make equivalent change in build_browser_app.bat ("xcopy src\* browser_build" changed to "xcopy src\main\*")
--------
Remove .bat and .sh scripts wrongly placed in . instead of ./bin